### PR TITLE
1.2.5 version of plugin, with CSS added to the page to support Exclus…

### DIFF
--- a/svn/trunk/SlickEngagement_Plugin.php
+++ b/svn/trunk/SlickEngagement_Plugin.php
@@ -395,7 +395,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
     {
         global $post;
         echo "\n";
-        echo '<meta property="slick:wpversion" content="1.2.4" />' . "\n";
+        echo '<meta property="slick:wpversion" content="1.2.5" />' . "\n";
         $siteCode = trim($this->getOption('SiteCode'));
         if ($siteCode) {
             $adThriveAbTest = false;
@@ -412,6 +412,9 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
                     }
                 }
             }
+            echo '<style>' . "\n";
+            echo '  .category-slickstream-exclusive { visibility: hidden; }' . "\n";
+            echo '</style>' . "\n";
             echo '<script>' . "\n";
             echo '"use strict";' . "\n";
             if ($adThriveAbTest) {
@@ -448,7 +451,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
 
         $ldJsonPlugin = (object) [
             '@type' => 'Plugin',
-            'version' => '1.2.4',
+            'version' => '1.2.5',
         ];
         array_push($ldJsonElements, $ldJsonPlugin);
 

--- a/svn/trunk/readme.txt
+++ b/svn/trunk/readme.txt
@@ -1,5 +1,5 @@
 === Slickstream: Engagement and Conversions ===
-Contributors: kduffie
+Contributors: kduffie, wpslickstream
 Donate link:  https://slickstream.com
 Tags: search,recommendations,favorites,navigation,engagement,better search,advanced search,category search,relevant search,carousel,bookmarks,stories
 License: GPLv2 or later

--- a/svn/trunk/readme.txt
+++ b/svn/trunk/readme.txt
@@ -6,7 +6,7 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 5.0
 Requires PHP: 5.6
-Tested up to: 6.0.1
+Tested up to: 6.0.2
 Stable tag: 1.2.4
 
 Use Slickstream to upgrade your site search.  Get beautiful as-you-type search, relevant content recommendations, user favorites and more!
@@ -232,3 +232,7 @@ It’s simple: [sign up for your free trial here](https://bloggers.slickstream.c
 
 = 1.2.4
 - Remove rendering of sensitive information 
+
+= 1.2.5
+- Add support for Slickstream exclusive content hiding
+

--- a/svn/trunk/slick-engagement.php
+++ b/svn/trunk/slick-engagement.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Slickstream Search and Engagement
 Plugin URI: https://slickstream.com/getting-started
-Version: 1.2.4
+Version: 1.2.5
 Author: Slickstream
 Author URI: https://slickstream.com
 Description: Use Slickstreams's cloud service and widgets to increase visitor engagement


### PR DESCRIPTION
…ive Content feature

This updates the Slickstream WordPress plugin to inject a small block of CSS that will hide content on pages that are part of the slickstream-exclusive category.  Without this, that content would be temporarily visible until the Slickstream client loads within the browser.  With this added, the content is all hidden until Slickstream loads in the browser at which point, it will expose the exclusive content if the user is signed in.

Note that after merging these changes in GitHub, you will need to publish the update to the plugin using svn commands.  This will require that you first become a committer on the Slickstream WordPress.org plugin.