### PR TITLE
SLICK-325 Add referer header to page boot data request in plugin

### DIFF
--- a/svn/trunk/SlickEngagement_Plugin.php
+++ b/svn/trunk/SlickEngagement_Plugin.php
@@ -300,7 +300,10 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
 
         $page_url = "$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
         $remote = self::defaultServerUrl . '/d/page-boot-data?site=' . $siteCode . '&url=' . rawurlencode($page_url);
-        $response = wp_remote_get( $remote , array( 'timeout' => 3 ) );
+        $response = wp_remote_get( $remote , array( 'timeout' => 3, 'headers' => array(
+                                                                        'referer' => home_url()
+                                                                    ) 
+        ) );
 
         if ( is_array($response) ) {
           $response_text = wp_remote_retrieve_body( $response );


### PR DESCRIPTION
Version 1.3.0 of the plugin caused some issues w/ the domain allow list. The request originating from the plugin does not have a referer header set by default. (See comment from ancientro https://developer.wordpress.org/reference/functions/wp_remote_get/)