### PR TITLE
[SLICK-1696] Updated readme to show support for Wordpress 6.7.0...

### DIFF
--- a/svn/trunk/SlickEngagement_Init.php
+++ b/svn/trunk/SlickEngagement_Init.php
@@ -1,11 +1,11 @@
 <?php 
 declare(strict_types=1);
-namespace Slickstream;
 
-function PluginInit(): void {
+function SlickEngagement_init(): void {
 
+    require_once 'SlickEngagement_PluginInit.php';
     require_once 'SlickEngagement_ActionsFilters.php';
-    $slickActionsFilters = new ActionsFilters();
+    $slickActionsFilters = new Slickstream\ActionsFilters();
 
     // NOTE: this file gets run each time you *activate* the plugin.
     // So in WP when you "install" the plugin, all that does it dump its files in the plugin-templates directory

--- a/svn/trunk/SlickEngagement_Plugin.php
+++ b/svn/trunk/SlickEngagement_Plugin.php
@@ -11,7 +11,7 @@ require_once 'SlickEngagement_PageBootData.php';
 require_once 'SlickEngagement_Utils.php';
 
 class SlickEngagement_Plugin extends OptionsManager  {
-    private const PLUGIN_VERSION = '2.0.2';
+    private const PLUGIN_VERSION = '2.0.3';
     private const DEFAULT_SERVER_URL = 'app.slickstream.com';
     private string $scriptClass = 'slickstream-script';
     private string $serverUrlBase;

--- a/svn/trunk/SlickEngagement_PluginInit.php
+++ b/svn/trunk/SlickEngagement_PluginInit.php
@@ -1,0 +1,9 @@
+<?php 
+declare(strict_types=1);
+namespace Slickstream;
+
+//Added for backwards compatibility; do not remove/rename
+function PluginInit(): void {
+    require_once 'SlickEngagement_Init.php';
+    \SlickEngagement_init();
+}

--- a/svn/trunk/readme.txt
+++ b/svn/trunk/readme.txt
@@ -1,13 +1,13 @@
 === Slickstream: Engagement and Conversions ===
-Contributors: kduffie,wpslickstream
+Contributors: wpslickstream,kduffie
 Donate link:  https://slickstream.com
 Tags: search,recommendations,favorites,engagement,bookmarks
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Requires at least: 5.0
-Requires PHP: 7.4
-Tested up to: 6.6.2
-Stable tag: 2.0.2
+Requires PHP: 7.4.0
+Tested up to: 6.7.0
+Stable tag: 2.0.3
 
 Use Slickstream to upgrade your site search.  Get beautiful as-you-type search, relevant content recommendations, user favorites and more!
 
@@ -151,7 +151,11 @@ You can find more information about Slickstream here on Slickstream.com.
 = 2.0.2 =
 - Upgrade lifecycle bug fix
 
+= 2.0.3 =
+- Restored `SlickEngagement_init()` function
+- Tested to be comaptible up to Wordpress 6.7.0
+
 == Upgrade Notice ==
 
-= 2.0.2 =
+= 2.0.3 =
 - We recommend all Slickstream sites upgrade to this latest plugin version for the best Slickstream experience. This new version includes enhancements to page load speeds, better configuration data caching, and enhanced security. NOTE: Slickstream Plugins 2.0.0+ require at leaset PHP 7.4.0.

--- a/svn/trunk/slick-engagement.php
+++ b/svn/trunk/slick-engagement.php
@@ -1,9 +1,10 @@
-<?php namespace Slickstream;
+<?php 
+namespace Slickstream;
 /*
  * Plugin Name:       Slickstream Search and Engagement
  * Plugin URI:        https://slickstream.com/
  * Description:       For use with Slickstream's cloud service and widgets to increase visitor engagement
- * Version:           2.0.2
+ * Version:           2.0.3
  * Requires at least: 5.2.0
  * Requires PHP:      7.4.0
  * Author:            Slickstream
@@ -24,7 +25,7 @@ function SlickstreamPluginInit(): void {
     if (version_compare((string) phpversion(), $minimumRequiredPhpVersion) < 0) {
         add_action('admin_notices', function() use ($minimumRequiredPhpVersion) {
             echo '<div class="updated fade">' .
-            __('Error: plugin "Slickstream Engagement" requires a newer version of PHP to be running.', 'slick-engagement') .
+            __('Error: plugin "Slickstream Engagement" requires a newer version of PHP to run properly.', 'slick-engagement') .
             '<br/>' . __('Minimum version of PHP required: ', 'slick-engagement') . '<strong>' . $minimumRequiredPhpVersion . '</strong>' .
             '<br/>' . __('Your server\'s PHP version: ', 'slick-engagement') . '<strong>' . phpversion() . '</strong>' .
             '</div>';
@@ -33,7 +34,7 @@ function SlickstreamPluginInit(): void {
     }
 
     require_once 'SlickEngagement_Init.php';
-    PluginInit();
+    \SlickEngagement_init();
 }
 
 SlickstreamPluginInit();


### PR DESCRIPTION
…and restored a function that CultivateWP was using to detect Slickstream.