### PR TITLE
Add Psalm Security Scanning

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -35,7 +35,8 @@ jobs:
           security_analysis: true
           report_file: results.sarif
           composer_ignore_platform_reqs: true
-          composer_require_dev: true
+          composer_require_dev: false
+          relative_dir: ./svn/trunk
 
       # - name: Psalm Security Scan
       #   uses: psalm/psalm-github-security-scan@f3e6fd9432bc3e44aec078572677ce9d2ef9c287

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Psalm Security Scan
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '23 3 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  php-security:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Psalm Security Scan
+        uses: psalm/psalm-github-security-scan@f3e6fd9432bc3e44aec078572677ce9d2ef9c287
+
+      - name: Upload Security Analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -29,8 +29,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Psalm Security Scan
-        uses: psalm/psalm-github-security-scan@f3e6fd9432bc3e44aec078572677ce9d2ef9c287
+      - name: Run Psalm Scan
+        uses: docker://vimeo/psalm-github-actions
+        with:
+          security_analysis: true
+          report_file: results.sarif
+          composer_ignore_platform_reqs: true
+          composer_require_dev: true
+
+      # - name: Psalm Security Scan
+      #   uses: psalm/psalm-github-security-scan@f3e6fd9432bc3e44aec078572677ce9d2ef9c287
 
       - name: Upload Security Analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to perform security scans using Psalm. The workflow is designed to run on pushes, pull requests to the `master` branch, and on a scheduled weekly basis.

### New GitHub Actions workflow:

* [`.github/workflows/psalm.yml`](diffhunk://#diff-d0547c297b4cf0631b625910fa903e937ff9bacee96c5ea6e2aec7cd236f0a75R1-R38): Added a new workflow named "Psalm Security Scan" to perform security scans using the Psalm GitHub Security Scan action. The workflow includes steps to checkout code, run the security scan, and upload the results to GitHub as SARIF files. It is triggered by pushes, pull requests to the `master` branch, and a weekly cron schedule.